### PR TITLE
feat: add DDD package skeleton and TDD infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,14 +27,40 @@ low-level `Client` plus a `weather.today()` helper.
 
 ## Project layout
 
+The package follows a lightweight **Domain-Driven Design (DDD)** layering.
+Dependencies flow inward: infrastructure can import domain, but domain
+cannot import infrastructure.
+
 ```
-src/openmeteo/       # the package
-tests/               # pytest suite
-.github/workflows/   # CI and release pipelines
-pyproject.toml       # single source of truth for config
-justfile             # task recipes
-CHANGELOG.md         # Keep a Changelog format
+src/openmeteo/
+├── __init__.py              # re-exports public API
+├── _exceptions.py           # error taxonomy
+├── domain/                  # pure domain, no IO
+│   ├── location.py          # Location value object
+│   ├── forecast.py          # Forecast aggregate root
+│   ├── variable.py          # Variable enum
+│   └── units.py             # UnitSystem enum
+├── application/             # orchestration / use cases
+│   ├── client.py            # low-level Client class
+│   └── weather.py           # high-level weather.today() helpers
+└── infrastructure/          # external integrations
+    ├── http.py              # httpx wrapper, retries, timeouts
+    ├── geocoding.py         # string -> (lat, lon)
+    └── openmeteo_api.py     # JSON <-> domain parsing
+
+tests/                       # pytest suite
+├── conftest.py              # registers @pytest.mark.not_implemented
+├── test_smoke.py
+└── test_weather_today.py    # example TDD red test
 ```
+
+**Layering rules (enforced by review, not yet by tooling):**
+- `domain/` imports nothing from this package.
+- `application/` imports from `domain/` and `infrastructure/`.
+- `infrastructure/` imports from `domain/` only.
+- `__init__.py` re-exports from `application/`.
+
+Flatten if a module grows beyond one clear purpose.
 
 ## Commands
 
@@ -57,6 +83,13 @@ Run `just` with no args for the full list.
 
 - **Always run `just check` before claiming a task is done.** Nothing ships
   without lint, types, and tests passing.
+- **Write the test first (TDD).** For any new public behavior, first add a
+  test describing what it should do, marked `@pytest.mark.not_implemented("reason")`.
+  Then implement until the test passes. Then remove the `not_implemented`
+  marker. See "TDD workflow" below.
+- **Respect the DDD layering.** Domain is pure; infrastructure talks to
+  the outside world; application orchestrates. Never import infrastructure
+  from domain. See "Project layout" above.
 - **Write type annotations on all new code.** `mypy --strict` is enforced.
 - **Use Python 3.11 syntax only.** Ruff and mypy are pinned to `target-version = "py311"`.
   Do not use 3.12+ features like `class Container[T]:` (PEP 695 generics) or
@@ -90,6 +123,64 @@ Run `just` with no args for the full list.
   (OIDC); no API tokens should appear in workflows, env vars committed to
   the repo, or anywhere else.
 - **Do not weaken the ruff or mypy configs** without explicit discussion.
+
+## TDD workflow
+
+We practice strict red-green-refactor with automatic cleanup enforcement.
+
+### The ritual
+
+1. **Add a test** describing the new behavior, marked `@pytest.mark.not_implemented("reason")`.
+   The marker (defined in `tests/conftest.py`) translates to a strict xfail.
+   ```python
+   import pytest
+
+   @pytest.mark.not_implemented("weather.today() is not implemented yet")
+   def test_weather_today_returns_current_temperature() -> None:
+       from openmeteo.application import weather
+       result = weather.today("Dresden")
+       assert result.temperature is not None
+   ```
+2. **Run `just check`.** The test fails (as intended); pytest reports
+   `XFAIL` and CI stays green.
+3. **Implement the behavior** in the appropriate layer (usually domain +
+   application).
+4. **Run `just check` again.** The test now passes. With `strict=True`,
+   pytest reports it as `XPASS` and **fails the test run** with a message
+   like `[XPASS(strict)] weather.today() is not implemented yet`.
+5. **Remove the `@pytest.mark.not_implemented(...)` marker.** The test
+   should now run as a normal passing test. Commit.
+
+### Why this works
+
+- Writing the test first forces you to think about the API before the
+  implementation.
+- `strict=True` means the marker cannot silently rot — the moment the
+  test passes, CI forces you to remove the marker.
+- No CI is "red on purpose"; TDD red tests live as xfail, not failure.
+
+### When `not_implemented` is NOT appropriate
+
+- **Behavior that should never work** — use `pytest.raises(NotImplementedError)` or
+  a regular assertion. Don't mark passing-by-failing as xfail.
+- **External dependencies that may be down** — use `@pytest.mark.skipif(...)` instead.
+- **Flaky tests** — fix the flakiness; don't hide it behind a marker.
+
+## DDD layering rules
+
+- **`domain/`** — pure. Value objects, aggregates, enums. Safe to use in
+  any context (sync, async, tests, notebooks). Imports no other layer of
+  this package.
+- **`application/`** — orchestration. `Client`, high-level helpers.
+  Depends on `domain/` and `infrastructure/`.
+- **`infrastructure/`** — IO. HTTP client, retries, JSON parsing, geocoding.
+  Depends on `domain/` only.
+- **Package root (`__init__.py`)** — re-exports the public API from
+  `application/` so users can write `from openmeteo import weather`
+  without knowing the internal structure.
+
+When in doubt, ask: *"If I removed the network, would this still make
+sense?"* If yes, it's probably domain. If no, it's infrastructure.
 
 ## Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   following the [agents.md convention](https://agents.md/). Codifies tooling,
   conventions, release flow, and the two-dep + no-FlatBuffers policies so
   agents don't need to re-derive them each session.
+- **Domain-Driven Design package skeleton** under `src/openmeteo/` with
+  `domain/`, `application/`, and `infrastructure/` layers. Each module is
+  a docstring-only placeholder for now. Layering rules documented in
+  `AGENTS.md` and `CONTRIBUTING.md`.
+- **Test-Driven Development support**: custom `@pytest.mark.not_implemented("reason")`
+  marker (registered in `tests/conftest.py`) that translates to a strict
+  `xfail`. Red tests pass CI while unimplemented; once they pass for real,
+  CI fails with a prompt to remove the marker. Example in
+  `tests/test_weather_today.py`.
 
 ## [0.0.3] - 2026-04-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,52 @@ just
 - **Docstrings:** Google style, required on public API
 - **Tests:** pytest, async tests supported (`pytest-asyncio`)
 
+## Architecture: Domain-Driven Design (light)
+
+The package is organized into three layers. Dependencies flow inward.
+
+- **`src/openmeteo/domain/`** — pure domain types (value objects, aggregates,
+  enums). No IO. No framework dependencies.
+- **`src/openmeteo/application/`** — use cases that orchestrate the domain
+  with infrastructure. The `Client` class and `weather.today()` helpers live here.
+- **`src/openmeteo/infrastructure/`** — HTTP, JSON parsing, retries, geocoding.
+  Depends on domain but not on application.
+
+When adding a feature, ask: "does this describe *what* weather is
+(domain), *how to get it* (infrastructure), or *a user's intent*
+(application)?"
+
+## Testing: Test-Driven Development
+
+We practice TDD with a custom pytest marker for pending behavior.
+
+```python
+import pytest
+
+@pytest.mark.not_implemented("weather.today() is not implemented yet")
+def test_weather_today() -> None:
+    from openmeteo.application import weather
+    result = weather.today("Dresden")
+    assert result.temperature is not None
+```
+
+- The `not_implemented` marker (registered in `tests/conftest.py`) translates
+  to a strict `pytest.mark.xfail`.
+- While the feature is missing, the test fails and pytest reports `XFAIL` —
+  CI stays green.
+- Once you implement the feature and the test passes, pytest reports
+  `XPASSED` and **fails CI** (because of `strict=True`), forcing you to
+  remove the marker.
+- Net effect: red → green → marker removed, automatically enforced.
+
+**Workflow:**
+1. Write the test first, marked `@pytest.mark.not_implemented("...")`.
+2. `just check` — test xfails, CI green.
+3. Implement the feature.
+4. `just check` — test xpasses, CI fails with a clear prompt.
+5. Remove the marker.
+6. `just check` — all green, commit.
+
 ## Commit messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/src/openmeteo/_exceptions.py
+++ b/src/openmeteo/_exceptions.py
@@ -1,0 +1,9 @@
+"""Exception hierarchy for open-meteo-client.
+
+Planned taxonomy:
+    OpenMeteoError          — base class
+        ├── ClientError     — 4xx or our request is malformed
+        │     ├── LocationNotFoundError
+        │     └── RateLimitError
+        └── TransportError  — network issues, timeouts, 5xx
+"""

--- a/src/openmeteo/application/__init__.py
+++ b/src/openmeteo/application/__init__.py
@@ -1,0 +1,7 @@
+"""Application layer — use cases and orchestration.
+
+Coordinates the domain with infrastructure to fulfill user intents. The
+`Client` class (low-level) and the `weather` module (high-level helpers)
+live here. Depends on domain and infrastructure; is depended on by the
+package's public `__init__`.
+"""

--- a/src/openmeteo/application/client.py
+++ b/src/openmeteo/application/client.py
@@ -1,0 +1,5 @@
+"""Low-level `Client` — one method per Open-Meteo endpoint.
+
+Planned: `Client` exposing `forecast(lat, lon, ...)`, `geocode(name)`, etc.
+Async, typed, returns domain objects. For users who want full control.
+"""

--- a/src/openmeteo/application/weather.py
+++ b/src/openmeteo/application/weather.py
@@ -1,0 +1,10 @@
+"""High-level convenience API.
+
+Planned helpers:
+    weather.today(location)       # current conditions by name or (lat, lon)
+    weather.tomorrow(location)    # tomorrow's summary
+    weather.forecast(location, days=7)
+
+Sits on top of the `Client` class, handles geocoding, sensible defaults,
+and human-friendly return shapes.
+"""

--- a/src/openmeteo/domain/__init__.py
+++ b/src/openmeteo/domain/__init__.py
@@ -1,0 +1,9 @@
+"""Domain layer — pure domain types and logic.
+
+No IO, no network, no framework dependencies. The domain layer describes
+the weather domain in its own vocabulary: forecasts, locations, variables,
+units. It is safe to import from anywhere; it imports from nowhere else in
+this package.
+
+Aggregates and value objects live here.
+"""

--- a/src/openmeteo/domain/forecast.py
+++ b/src/openmeteo/domain/forecast.py
@@ -1,0 +1,5 @@
+"""Aggregate root: a weather forecast for a location.
+
+Planned: `Forecast` aggregate composed of a `Location`, a time window, and
+one or more time-series of `Variable` values.
+"""

--- a/src/openmeteo/domain/location.py
+++ b/src/openmeteo/domain/location.py
@@ -1,0 +1,5 @@
+"""Value object: a geographical location.
+
+Planned: `Location` value object holding latitude, longitude, optional name.
+Value objects are immutable and compared by value, not identity.
+"""

--- a/src/openmeteo/domain/units.py
+++ b/src/openmeteo/domain/units.py
@@ -1,0 +1,6 @@
+"""Unit systems: metric (default) and imperial.
+
+Planned: `UnitSystem` enum driving the `temperature_unit`, `wind_speed_unit`,
+and `precipitation_unit` parameters on requests. Metric is default; callers
+can override with `units="imperial"` on high-level helpers.
+"""

--- a/src/openmeteo/domain/variable.py
+++ b/src/openmeteo/domain/variable.py
@@ -1,0 +1,7 @@
+"""Weather variables (temperature_2m, precipitation, etc.).
+
+Planned: `Variable` StrEnum auto-generated from Open-Meteo's OpenAPI spec.
+A `Variable | str` union type lets callers pass enum members for
+autocomplete, or raw strings as an escape hatch for variables Open-Meteo
+may add before we regenerate.
+"""

--- a/src/openmeteo/infrastructure/__init__.py
+++ b/src/openmeteo/infrastructure/__init__.py
@@ -1,0 +1,6 @@
+"""Infrastructure layer — external integrations.
+
+Everything that touches the outside world: HTTP via `httpx`, JSON parsing,
+retries, backoff, geocoding. Implements ports described by the application
+layer; depends on domain types but never the other way around.
+"""

--- a/src/openmeteo/infrastructure/geocoding.py
+++ b/src/openmeteo/infrastructure/geocoding.py
@@ -1,0 +1,6 @@
+"""Geocoding adapter: resolve a place name to (lat, lon).
+
+Planned: uses Open-Meteo's geocoding API. Results are cached in-process
+for the lifetime of a `Client` to avoid redundant lookups for repeated
+calls like `weather.today("Dresden")`.
+"""

--- a/src/openmeteo/infrastructure/http.py
+++ b/src/openmeteo/infrastructure/http.py
@@ -1,0 +1,5 @@
+"""HTTP transport adapter built on `httpx.AsyncClient`.
+
+Planned: a thin async HTTP wrapper with sensible timeouts, retry/backoff,
+and error mapping into the domain's exception types.
+"""

--- a/src/openmeteo/infrastructure/openmeteo_api.py
+++ b/src/openmeteo/infrastructure/openmeteo_api.py
@@ -1,0 +1,6 @@
+"""Open-Meteo API request builder and response parser.
+
+Planned: maps between domain concepts and Open-Meteo's JSON wire format.
+Pydantic models with `extra="allow"` so new fields from Open-Meteo don't
+break existing callers.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared pytest configuration.
+
+Registers the `not_implemented` marker used to signal TDD red tests that
+describe future behavior. A test marked `not_implemented` is expected to
+fail until someone implements the feature; once it passes, pytest will
+turn it into a hard failure, prompting the author to remove the marker.
+
+Usage:
+    @pytest.mark.not_implemented("weather.today is not implemented yet")
+    def test_weather_today_in_dresden() -> None:
+        result = weather.today("Dresden")
+        assert result.temperature is not None
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers so --strict-markers doesn't complain."""
+    config.addinivalue_line(
+        "markers",
+        "not_implemented(reason): TDD red test. Expected to fail until the "
+        "feature is implemented. Passes turn into failures (strict xfail) "
+        "to force removal of the marker once the code catches up.",
+    )
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Translate `@pytest.mark.not_implemented(reason)` into a strict xfail."""
+    for item in items:
+        marker = item.get_closest_marker("not_implemented")
+        if marker is None:
+            continue
+        reason = marker.args[0] if marker.args else "not implemented yet"
+        item.add_marker(pytest.mark.xfail(reason=reason, strict=True))

--- a/tests/test_weather_today.py
+++ b/tests/test_weather_today.py
@@ -1,0 +1,23 @@
+"""Red tests describing the v0.1.0 high-level API.
+
+These tests define the intended behavior of `openmeteo.weather.today(...)`
+and friends. They are marked `not_implemented` and will pass as xfail
+until the feature is built. Once implemented, remove the marker and the
+test stays green.
+"""
+
+import pytest
+
+
+@pytest.mark.not_implemented("weather.today() is not implemented yet")
+def test_weather_today_returns_something_for_known_city() -> None:
+    """`weather.today("Dresden")` returns a Forecast-like object with a
+    non-None temperature for today."""
+    # Delayed import: importing `weather` from openmeteo currently fails
+    # because the module is just a docstring placeholder. Once implemented,
+    # this will exercise the real code.
+    from openmeteo.application import weather  # noqa: PLC0415  (explicit lazy)
+
+    result = weather.today("Dresden")  # type: ignore[attr-defined]
+    assert result is not None
+    assert result.temperature is not None  # type: ignore[union-attr]


### PR DESCRIPTION
Structure the package around lightweight Domain-Driven Design and add
pytest infrastructure for Test-Driven Development.

DDD layers (docstring-only placeholders for now):
- src/openmeteo/domain/     pure domain (Location, Forecast, Variable, UnitSystem)
- src/openmeteo/application/ use cases (Client, weather.today helpers)
- src/openmeteo/infrastructure/ HTTP, geocoding, Open-Meteo API adapter
- src/openmeteo/_exceptions.py error taxonomy sketch

Dependencies flow inward:
- domain imports nothing from the package
- application imports domain + infrastructure
- infrastructure imports only domain

TDD infrastructure:
- tests/conftest.py registers @pytest.mark.not_implemented(reason) which
  translates to @pytest.mark.xfail(strict=True). Red tests pass CI while
  pending; once they actually pass, strict xfail turns that into a hard
  failure, forcing the author to remove the marker.
- tests/test_weather_today.py demonstrates the pattern.

Docs updated:
- AGENTS.md: project-layout section, TDD workflow, DDD layering rules,
  'write the test first' added to Must list.
- CONTRIBUTING.md: architecture and testing sections explaining DDD + TDD
  for human contributors.
- CHANGELOG.md: Unreleased entry.

Signed-off-by: Jakob Heine <me@jakobheine.de>
