### PR TITLE
docs: link to public Roadmap project board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Link to the public [Roadmap project board](https://github.com/users/jakobheine/projects/1)
+  in the README.
 - `AGENTS.md` — instructions for AI coding assistants working in the repo,
   following the [agents.md convention](https://agents.md/). Codifies tooling,
   conventions, release flow, and the two-dep + no-FlatBuffers policies so

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ pip install open-meteo-client
 
 > ⚠️ Package reserved — no functionality yet. Check back for v0.1.0.
 
+## Roadmap
+
+Public roadmap and backlog live on the [**Roadmap project board**](https://github.com/users/jakobheine/projects/1).
+Pick anything from the Backlog column that's not claimed — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for release notes.


### PR DESCRIPTION
Add a 'Roadmap' section to README.md pointing at
https://github.com/users/jakobheine/projects/1, the public board where
contributors can pick up backlog items.

Signed-off-by: Jakob Heine <me@jakobheine.de>
