### PR TITLE
ci: upload coverage to Codecov with 95% threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,36 @@
+# Codecov configuration
+# Docs: https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  # Round displayed percentages to 2 decimals
+  round: down
+  precision: 2
+  range: "90...100"
+
+  status:
+    # Overall project coverage — must stay at or above target
+    project:
+      default:
+        target: 95%
+        # Allow small natural fluctuations; fail PRs that drop coverage meaningfully
+        threshold: 0.5%
+        # Ignore any changes that would only occur in the informational branch
+        if_ci_failed: error
+
+    # Coverage of lines changed in the patch — new code must be well tested
+    patch:
+      default:
+        target: 95%
+        threshold: 0.5%
+        if_ci_failed: error
+
+# Include PR comments with coverage delta + list of uncovered lines
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+# Don't measure coverage of tests themselves
+ignore:
+  - "tests/"
+  - "scripts/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,12 @@ jobs:
         run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run tests with coverage
-        run: uv run --python ${{ matrix.python-version }} pytest --cov=openmeteo --cov-report=xml --cov-report=term
+        run: uv run --python ${{ matrix.python-version }} pytest --cov=openmeteo --cov-branch --cov-report=xml --cov-report=term
 
-      - name: Upload coverage
+      - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v7
+        uses: codecov/codecov-action@v5
         with:
-          name: coverage-xml
-          path: coverage.xml
-          if-no-files-found: ignore
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    # Required for Codecov tokenless OIDC upload (public repos).
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +66,6 @@ jobs:
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          fail_ci_if_error: false
+          use_oidc: true
+          fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Codecov integration (`.codecov.yml`, workflow upload, README badge) with
+  a 95% coverage target enforced on both project and patch coverage.
 - Monthly-downloads badge (pepy.tech) in the README.
 - Link to the public [Roadmap project board](https://github.com/users/jakobheine/projects/1)
   in the README.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # open-meteo-client
 
 [![CI](https://github.com/jakobheine/open-meteo-client/actions/workflows/ci.yml/badge.svg)](https://github.com/jakobheine/open-meteo-client/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/jakobheine/open-meteo-client/graph/badge.svg)](https://codecov.io/gh/jakobheine/open-meteo-client)
 [![PyPI version](https://img.shields.io/pypi/v/open-meteo-client.svg)](https://pypi.org/project/open-meteo-client/)
 [![Python versions](https://img.shields.io/pypi/pyversions/open-meteo-client.svg)](https://pypi.org/project/open-meteo-client/)
 [![Downloads](https://static.pepy.tech/badge/open-meteo-client/month)](https://pepy.tech/project/open-meteo-client)


### PR DESCRIPTION
- Replace artifact upload with codecov/codecov-action@v5
- Add --cov-branch for branch coverage
- Create .codecov.yml: 95% target, 0.5% threshold, both project and patch
- Ignore tests/ and scripts/ from coverage measurement
- Add Codecov badge to README
- Requires CODECOV_TOKEN secret (configured)

Closes #9

Signed-off-by: Jakob Heine <me@jakobheine.de>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Codecov for automated code coverage monitoring and enforcement at 95% threshold for overall project and patch coverage.
  * Added branch coverage measurement to CI pipeline.

* **Documentation**
  * Added Codecov coverage badge to README for visibility of coverage status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->