### PR TITLE
ci(coderabbit): disable auto-review, trigger manually via comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,37 @@
+# CodeRabbit configuration
+# Docs: https://docs.coderabbit.ai/reference/configuration
+#
+# Policy: CodeRabbit is rate-limited to 1 review/hour on the free tier.
+# We keep it opt-in so reviews are saved for meaningful PRs instead of
+# being burned on trivial docs or infra tweaks.
+#
+# To trigger a review on a specific PR, comment on it:
+#   @coderabbitai review      — review since last review
+#   @coderabbitai full review  — review from scratch
+#
+# Also supports pausing, resolving, resummarizing, etc. — see docs.
+
+language: "en"
+early_access: false
+
+reviews:
+  # Don't auto-review every new PR.
+  auto_review:
+    enabled: false
+    drafts: false
+
+  # Still generate PR summaries (cheap, doesn't count against review limit)
+  high_level_summary: true
+  poem: true
+
+  # Request-changes only when genuinely needed, not on style nits
+  request_changes_workflow: true
+
+  # Skip trivial PRs even when triggered manually (too small to review)
+  review_status: true
+
+  # Post a poem + walkthrough on the PR for context
+  profile: "assertive"
+
+chat:
+  auto_reply: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,15 @@ gh release create vX.Y.Z --generate-notes --title "vX.Y.Z"
 - **Public API surface:** `src/openmeteo/__init__.py` (currently just exposes
   `__version__`; will re-export the intended public API once it exists)
 
+## Code review
+
+- **CodeRabbit** is installed but **opt-in** to respect free-tier rate limits
+  (1 review per hour). To request a review, comment on the PR:
+  - `@coderabbitai review` — review changes since last review
+  - `@coderabbitai full review` — review from scratch
+- Use it on meaningful code PRs, not docs/infra tweaks where ruff + mypy
+  already cover the ground.
+
 ## When unsure
 
 Stop and ask. Small, focused PRs with questions are better than large PRs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CodeRabbit configured opt-in via `.coderabbit.yaml` (trigger with
+  `@coderabbitai review` comment) to respect free-tier rate limits.
+
 ### Added
 - Codecov integration (`.codecov.yml`, workflow upload, README badge) with
   a 95% coverage target enforced on both project and patch coverage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,9 @@ Please **sign off** your commits (`git commit -s`).
    is user-visible.
 4. **Open the PR** — keep it focused (one logical change per PR).
 5. CI will run on your PR — please make sure it passes.
+6. **(Optional) Request an AI review** by commenting `@coderabbitai review`
+   on the PR. CodeRabbit is opt-in to respect free-tier rate limits; use it
+   on non-trivial changes where a second pair of eyes helps.
 
 ## Reporting bugs
 


### PR DESCRIPTION
Free-tier rate limits us to 1 review per hour. Save it for meaningful
PRs — ruff + mypy already cover style and types.

To request a review: comment '@coderabbitai review' on the PR.

Signed-off-by: Jakob Heine <me@jakobheine.de>
