### PR TITLE
refactor(tests/live): derive stable-field assertions from the fixture

### DIFF
--- a/tests/live/test_live_weather_today.py
+++ b/tests/live/test_live_weather_today.py
@@ -1,45 +1,59 @@
-"""Live canary: weather.today('Dresden') against the real Open-Meteo API.
+"""Live canary: openmeteo.today('Dresden') against the real Open-Meteo API.
 
-This test hits the real network. It's excluded from default `just test` runs
-and picked up by the scheduled workflow.
+Excluded from default `just test` runs; picked up by the scheduled
+`live.yml` workflow.
 
-Assertion philosophy (see tests/live/README.md):
-- **Exact** assertions for things we control (lat, lon we send) or that
-  are derived-but-stable (timezone)
-- **Structural / existence** assertions for fields we expect Open-Meteo
-  to return
-- **Range** assertions for volatile values (temperature changes every hour)
+Assertion philosophy:
+
+- **Stable fields** (lat, lon, timezone) — compare against the fixture
+  with a small tolerance. If Open-Meteo starts returning different
+  coordinates for Dresden, we want to know.
+- **Structural existence** — any field in the fixture must also exist
+  in the live response. Catches Open-Meteo deprecations automatically
+  as long as we refresh the fixture periodically.
+- **Volatile fields** (temperature, precipitation, wind, etc.) — check
+  only that they're within absolute plausible ranges. Fixture values
+  would be wrong half the year.
 """
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
+
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "today_dresden.json"
+FIXTURE: dict[str, Any] = json.loads(FIXTURE_PATH.read_text())
 
 
 @pytest.mark.live
 @pytest.mark.not_implemented("openmeteo.today() is not implemented yet")
 async def test_live_today_in_dresden() -> None:
     """`openmeteo.today('Dresden')` returns a sensible current forecast."""
-    import openmeteo  # noqa: PLC0415  (import late so xfail bails before ModuleNotFoundError)
+    import openmeteo  # noqa: PLC0415  (imported late so xfail bails cleanly)
 
     result = await openmeteo.today("Dresden")
 
-    # --- Exact / stable ---
-    # Open-Meteo rounds lat/lon slightly; Dresden is ~51.05 N, 13.74 E.
-    assert 51.0 < result.latitude < 51.1
-    assert 13.7 < result.longitude < 13.8
-    # Dresden is in the Berlin timezone and that's not going to change.
-    assert result.timezone == "Europe/Berlin"
+    # --- Stable fields vs fixture (with small tolerance) ---
+    assert result.latitude == pytest.approx(FIXTURE["latitude"], abs=0.1)
+    assert result.longitude == pytest.approx(FIXTURE["longitude"], abs=0.1)
+    assert result.timezone == FIXTURE["timezone"]
 
-    # --- Structural / existence ---
-    # The 'current' block is what today() is built on.
-    assert result.current is not None
-    assert isinstance(result.current.temperature_2m, float)
-    assert isinstance(result.current.weather_code, int)
+    # --- Structural: every field in the fixture must still exist ---
+    current_dict = result.current.model_dump()
+    fixture_current_fields = set(FIXTURE["current"].keys())
+    missing = fixture_current_fields - set(current_dict.keys())
+    assert not missing, (
+        f"Fields present in the fixture but missing from the live response: {missing}. "
+        f"Open-Meteo may have renamed or removed them."
+    )
 
-    # --- Sanity ranges (value changes hourly; just catch nonsense) ---
+    # --- Volatile fields: absolute plausible ranges ---
+    # Temperature in °C, plausible anywhere on Earth (Dresden: -40 to 50 is ample).
     assert -40 < result.current.temperature_2m < 50, (
         f"temperature {result.current.temperature_2m}°C out of plausible range"
     )
     assert 0 <= result.current.relative_humidity_2m <= 100
-    assert 0 <= result.current.precipitation < 200
+    assert 0 <= result.current.precipitation < 200  # mm in one observation interval
     assert 0 <= result.current.weather_code <= 100  # WMO codes live in [0, 100]
-    assert 0 <= result.current.wind_speed_10m < 300  # km/h; tornados excepted
+    assert 0 <= result.current.wind_speed_10m < 300  # km/h


### PR DESCRIPTION
Rather than hardcoding reference values for Dresden's lat/lon/timezone,
read them from tests/fixtures/today_dresden.json. Keeps the test in sync
when the fixture is refreshed.

Volatile values (temperature, precipitation, wind, humidity, weather
code) stay on absolute plausible ranges — fixture values would be wrong
half the year as seasons change.

Added a structural-existence check: every field present in the fixture's
'current' block must also be present in the live response. Catches
Open-Meteo deprecations automatically.

Signed-off-by: Jakob Heine <me@jakobheine.de>
