### PR TITLE
ci(publish): run live tests before publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,10 @@ name: Publish to PyPI
 # Flow:
 #   1. `git tag v0.1.0 && git push --tags`
 #   2. Go to GitHub → Releases → "Draft a new release" → select tag → Publish
-#   3. This workflow runs and uploads to PyPI via Trusted Publishing.
+#   3. Build artifacts → run live tests → manual approval → upload to PyPI.
+#
+# If the live tests fail, the approval gate never appears and publish never
+# runs. Fix the issue, re-trigger the release.
 on:
   release:
     types: [published]
@@ -36,9 +39,31 @@ jobs:
           name: dist
           path: dist/
 
+  live-check:
+    name: Live tests against real API
+    needs: build
+    runs-on: ubuntu-latest
+    # Release-time is stricter than the nightly canary: we only ship if the
+    # real API + our code are actually working right now. pytest-rerunfailures
+    # still retries twice to forgive a single network hiccup.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.14"
+
+      - name: Install project + dev dependencies
+        run: uv sync --all-extras
+
+      - name: Run live tests
+        run: uv run pytest -m live tests/live --reruns 2 --reruns-delay 3 -v
+
   publish:
     name: Publish to PyPI
-    needs: build
+    needs: [build, live-check]
     runs-on: ubuntu-latest
 
     # GitHub Environment — provides an approval gate (optional, recommended).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,15 +209,17 @@ sense?"* If yes, it's probably domain. If no, it's infrastructure.
 
 ```bash
 # 1. Bump version in src/openmeteo/__init__.py
-# 2. Bump matching assertion in tests/test_smoke.py
-# 3. Move CHANGELOG [Unreleased] entries into a dated [X.Y.Z] section
-# 4. Commit + push via PR
-# 5. After merge to main:
+# 2. Move CHANGELOG [Unreleased] entries into a dated [X.Y.Z] section
+# 3. Commit + push via PR
+# 4. After merge to main:
 git tag vX.Y.Z
 git push --tags
 gh release create vX.Y.Z --generate-notes --title "vX.Y.Z"
-# 6. The publish workflow triggers and waits for manual approval in the
-#    'pypi' GitHub Environment. A human must click "Approve and deploy".
+# 5. The publish workflow triggers and runs three jobs in order:
+#    build → live-check → publish (with 'pypi' environment approval).
+#    If live-check fails (real API broken or our code broken against it),
+#    publish never runs. Fix it, re-trigger the release.
+#    A human must click "Approve and deploy" before the publish step.
 #    Do not bypass this approval gate.
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `just test-live` now retries each test up to 2 times with a 3s delay
   to tolerate transient network hiccups.
+- **Release pipeline now runs live tests before publish.** The
+  `publish.yml` workflow is `build → live-check → publish`; if live
+  tests fail, the `pypi` approval gate never appears and nothing is
+  published. Forces "shippable now, against the real API" as a literal
+  release gate.
 - **Restructured test layout** into `tests/unit/` (pure, no mocks),
   `tests/integration/` (mocked httpx), and `tests/live/` (real API,
   marked `@pytest.mark.live`, excluded from default runs). Each has a


### PR DESCRIPTION
Insert a live-check job between build and publish in publish.yml:

  build → live-check → publish (with pypi approval)

Release-time stance is stricter than the nightly canary: we only ship if
the real API + our code work right now. If live-check fails, the
approval gate never appears and nothing is published.

The existing pytest-rerunfailures retry (2x, 3s delay) still forgives a
single transient hiccup.

Signed-off-by: Jakob Heine <me@jakobheine.de>
