### PR TITLE
fix(docs): use standard RTD python.install block

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,15 +7,13 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.14"
-  jobs:
-    # Use uv to install; faster + matches our local dev loop.
-    create_environment:
-      - asdf plugin add uv
-      - asdf install uv latest
-      - asdf global uv latest
-      - uv venv
-    install:
-      - uv pip install .[docs]
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
The custom 'create_environment' jobs installed uv and created a .venv/,
but Read the Docs runs sphinx-build against its own managed venv at
envs/latest/bin/python — which our custom setup never populated.
Result: 'python: not found' with exit code 127.

Switch to the standard 'python.install' block so RTD manages the venv
and installs our package + docs extras into the venv it actually uses.

Signed-off-by: Jakob Heine <me@jakobheine.de>
