### PR TITLE
docs: cross-site nav between README, docs, and PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Cross-site nav: a top-of-page link row in both `README.md` (GitHub) and
+  `docs/index.md` (RTD), plus Sphinx's "Edit on GitHub" link on every
+  docs page. PyPI already surfaces GitHub + Docs via `project.urls`.
+
 ## [0.0.5] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
+**[📖 Documentation](https://open-meteo-client.readthedocs.io/)** ·
+**[📦 PyPI](https://pypi.org/project/open-meteo-client/)** ·
+**[💬 Discussions](https://github.com/jakobheine/open-meteo-client/discussions)** ·
+**[🗺️ Roadmap](https://github.com/users/jakobheine/projects/1)**
+
+---
+
 A lightweight, async Python client for the [Open-Meteo](https://open-meteo.com) weather API — with high-level helpers that fit on a sticky note.
 
 ```python

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,3 +84,13 @@ html_theme_options = {
     "navigation_depth": 3,
     "includehidden": True,
 }
+
+# Extra links in the sidebar (rendered below the TOC)
+# Format: {label: URL}
+html_context = {
+    "display_github": True,
+    "github_user": "jakobheine",
+    "github_repo": "open-meteo-client",
+    "github_version": "main",
+    "conf_py_path": "/docs/",
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,12 @@
 # open-meteo-client
 
+**[📦 PyPI](https://pypi.org/project/open-meteo-client/)** ·
+**[🐙 GitHub](https://github.com/jakobheine/open-meteo-client)** ·
+**[💬 Discussions](https://github.com/jakobheine/open-meteo-client/discussions)** ·
+**[🗺️ Roadmap](https://github.com/users/jakobheine/projects/1)**
+
+---
+
 A lightweight, async Python client for the [Open-Meteo](https://open-meteo.com) weather API — with high-level helpers that fit on a sticky note.
 
 ```python


### PR DESCRIPTION
- README: top-level nav row (Docs, PyPI, Discussions, Roadmap)
- docs/index.md: top-level nav row (PyPI, GitHub, Discussions, Roadmap)
- conf.py: enable 'Edit on GitHub' link on every Sphinx page
- PyPI already surfaces all three via project.urls (shipped in 0.0.5)

Signed-off-by: Jakob Heine <me@jakobheine.de>
