### PR TITLE
docs: move cross-site nav row below Contents on RTD landing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,5 @@
 # open-meteo-client
 
-**[📦 PyPI](https://pypi.org/project/open-meteo-client/)** ·
-**[🐙 GitHub](https://github.com/jakobheine/open-meteo-client)** ·
-**[💬 Discussions](https://github.com/jakobheine/open-meteo-client/discussions)** ·
-**[🗺️ Roadmap](https://github.com/users/jakobheine/projects/1)**
-
----
-
 A lightweight, async Python client for the [Open-Meteo](https://open-meteo.com) weather API — with high-level helpers that fit on a sticky note.
 
 ```python
@@ -70,3 +63,12 @@ how-to/index
 reference/index
 explanation/index
 ```
+
+---
+
+## Elsewhere
+
+**[📦 PyPI](https://pypi.org/project/open-meteo-client/)** ·
+**[🐙 GitHub](https://github.com/jakobheine/open-meteo-client)** ·
+**[💬 Discussions](https://github.com/jakobheine/open-meteo-client/discussions)** ·
+**[🗺️ Roadmap](https://github.com/users/jakobheine/projects/1)**


### PR DESCRIPTION
The nav row was too prominent at the top. Push it below the TOC as an
'Elsewhere' footer; it's a useful escape hatch but shouldn't distract
from the Diátaxis table and install instructions.

Signed-off-by: Jakob Heine <me@jakobheine.de>
